### PR TITLE
Add Bullet Points around Planet and Satellite Information

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -107,7 +107,7 @@ function App() {
                 </h3>
                 <h3>
                   {" "}
-                  Mean Temprature of {data.englishName} : {data.avgTemp} K{" "}
+                  Mean Temperature of {data.englishName} : {data.avgTemp} K{" "}
                 </h3>
                 <h3>
                   {" "}

--- a/src/components/index.css
+++ b/src/components/index.css
@@ -155,6 +155,7 @@ input[type="submit"]:hover {
   font-size: 1.5rem;
   font-weight: 300;
   display: list-item;
+  list-style-type: '🪐';
   list-style-position: inside;
 }
 

--- a/src/components/index.css
+++ b/src/components/index.css
@@ -154,6 +154,8 @@ input[type="submit"]:hover {
   font-family: Poppins;
   font-size: 1.5rem;
   font-weight: 300;
+  display: list-item;
+  list-style-position: inside;
 }
 
 .deepbox p {

--- a/src/components/satellite/Satellite.js
+++ b/src/components/satellite/Satellite.js
@@ -143,7 +143,7 @@ export default class Satellite extends Component {
                 Operator : {this.state.data.moderateInfo.operator ?? "N/A"}
               </h3>
               <h3>
-                Sattelite Bus :{" "}
+                Satellite Bus :{" "}
                 {this.state.data.moderateInfo.sattelite_bus ?? "N/A"}
               </h3>
             </div>

--- a/src/components/satellite/Satellite.module.css
+++ b/src/components/satellite/Satellite.module.css
@@ -17,3 +17,9 @@
   position: relative;
   top: 15px;
 }
+
+.Satellite_satellite-info__2UzBF h3, [class*="satellite-info"] h3 {
+  display: list-item;
+  list-style-type: '🛰 ';
+  list-style-position: inside;
+}


### PR DESCRIPTION
This small pull request adds bullet points around the planet information `<h3>` tags using CSS, and also fixed spelling of temperature in 2nd Heading of Mean *Temperature* of planets.

![space-voyager vercel app_planets](https://user-images.githubusercontent.com/57865187/136408159-9dcaafef-dd37-4308-8c37-70e80804280f.png)
 
Please have a look, and comment below for any further updations required in it and merge it if this small change seems fine. 